### PR TITLE
Fix Python executable detection for Windows compatibility

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -17,8 +17,9 @@ let isDev = process.argv.includes('--dev');
 
 // ── Spawn Python backend ──────────────────────────────────────────────────────
 function spawnBackend() {
-  console.log(`Spawning backend: python3 ${BACKEND_SCRIPT} ${P2P_PORT}`);
-  pythonProcess = spawn('python3', [BACKEND_SCRIPT, String(P2P_PORT)], {
+  const pythonExe = process.platform === 'win32' ? 'python' : 'python3';
+  console.log(`Spawning backend: ${pythonExe} ${BACKEND_SCRIPT} ${P2P_PORT}`);
+  pythonProcess = spawn(pythonExe, [BACKEND_SCRIPT, String(P2P_PORT)], {
     cwd: path.join(__dirname, '..'),
     stdio: ['ignore', 'pipe', 'pipe'],
   });


### PR DESCRIPTION
## Summary
Updated the backend spawning logic to use the correct Python executable name based on the operating system, ensuring compatibility across Windows and Unix-like systems.

## Key Changes
- Added platform detection to select the appropriate Python executable (`python` on Windows, `python3` on other platforms)
- Updated the console log message to reflect the actual executable being used
- Modified the `spawn()` call to use the dynamically determined Python executable

## Implementation Details
The change uses `process.platform === 'win32'` to detect Windows and selects the corresponding Python executable name. This addresses the common issue where Windows typically uses `python` while Unix-like systems (Linux, macOS) use `python3` in their PATH.

https://claude.ai/code/session_01PTXgGeN4FZ9ZQx1kdLMq9W