### PR TITLE
Ensure UTF-8 encoding for Python backend stdio streams

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -42,6 +42,7 @@ function spawnBackend() {
   pythonProcess = spawn(pythonExe, [BACKEND_SCRIPT, String(P2P_PORT)], {
     cwd: path.join(__dirname, '..'),
     stdio: ['ignore', 'pipe', 'pipe'],
+    env: { ...process.env, PYTHONUTF8: '1' },
   });
 
   pythonProcess.stdout.on('data', (data) => {

--- a/electron_backend.py
+++ b/electron_backend.py
@@ -7,6 +7,10 @@ Run: python electron_backend.py [p2p_port]   (default: 6000)
 Flask listens on 127.0.0.1:5000
 """
 import sys
+if sys.stdout.encoding and sys.stdout.encoding.lower() != 'utf-8':
+    sys.stdout.reconfigure(encoding='utf-8')
+if sys.stderr.encoding and sys.stderr.encoding.lower() != 'utf-8':
+    sys.stderr.reconfigure(encoding='utf-8')
 import json
 import time
 import threading


### PR DESCRIPTION
## Summary
This PR ensures that the Python backend process uses UTF-8 encoding for all standard I/O streams, preventing encoding-related issues when the system default encoding differs from UTF-8.

## Key Changes
- **electron/main.js**: Set the `PYTHONUTF8` environment variable to `'1'` when spawning the Python backend process, which instructs Python to use UTF-8 encoding by default
- **electron_backend.py**: Added explicit reconfiguration of `sys.stdout` and `sys.stderr` to UTF-8 encoding at startup, with checks to only reconfigure if the current encoding is not already UTF-8

## Implementation Details
The changes use a two-pronged approach:
1. The Electron main process sets `PYTHONUTF8=1` as an environment variable, which is the recommended way to enable UTF-8 mode in Python 3
2. The Python backend includes a fallback mechanism that explicitly reconfigures stdout and stderr streams if they're not already UTF-8, ensuring compatibility across different system configurations and Python versions

This prevents potential encoding errors when the application runs on systems with non-UTF-8 default encodings (e.g., Windows with legacy code pages).

https://claude.ai/code/session_01Qn36jDVUuUPPkQfqc6GYYL