### PR TITLE
Refactor allocation tracking and fix timezone handling

### DIFF
--- a/blockchain/blockchain.py
+++ b/blockchain/blockchain.py
@@ -406,7 +406,7 @@ class Blockchain:
         return balance
 
     def allocation(self):
-        allocated = set()
+        allocated = {}
 
         for blk in self.chain:
             for tx in blk.transactions:
@@ -414,9 +414,9 @@ class Blockchain:
                     # Only regular requests (10) and buyouts (>10) add to allocation
                     # Penalties (<10) don't change allocation
                     if tx.amount >= ITEM_REQUEST_COST:
-                        allocated.add(tx.uid)
+                        allocated[tx.uid] = tx.requester
                 elif tx.tx_type == TxTypes.RELEASE:
-                    allocated.discard(tx.uid)
+                    allocated.pop(tx.uid, None)
 
         return allocated
 

--- a/electron_backend.py
+++ b/electron_backend.py
@@ -17,7 +17,7 @@ import threading
 import queue
 from collections import deque
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 
 from flask import Flask, jsonify, request, Response, stream_with_context, send_from_directory
@@ -143,7 +143,7 @@ def _build_broadcast_payload() -> dict:
     txs_per_block = [len(b["transactions"]) for b in blocks]
     block_indexes = [b["index"] for b in blocks]
     block_time_labels = [
-        datetime.utcfromtimestamp(float(b["timestamp"])).isoformat() + "Z"
+        datetime.fromtimestamp(float(b["timestamp"]), tz=timezone.utc).isoformat()
         for b in blocks
     ]
     allocated = chain.allocation()


### PR DESCRIPTION
## Summary
This PR makes two key improvements: refactoring the allocation tracking data structure from a set to a dictionary, and fixing timezone-aware datetime handling in the backend.

## Key Changes
- **Allocation tracking refactor**: Changed `allocated` from a `set` to a `dict` in `blockchain.allocation()` to store both the UID and the requester information. This enables better tracking of who requested each allocation.
  - Updated `allocated.add(tx.uid)` to `allocated[tx.uid] = tx.requester`
  - Updated `allocated.discard(tx.uid)` to `allocated.pop(tx.uid, None)` for safe removal

- **Timezone handling fix**: Replaced deprecated `datetime.utcfromtimestamp()` with timezone-aware `datetime.fromtimestamp(..., tz=timezone.utc)` in `electron_backend.py`
  - Removed the manual "Z" suffix since `isoformat()` now properly includes timezone information
  - Added `timezone` import from the `datetime` module

## Implementation Details
The allocation dictionary now maintains a mapping of UIDs to requesters, which provides better auditability and allows for future features that may need to know who requested a particular allocation. The timezone fix ensures proper handling of UTC timestamps and follows Python best practices for timezone-aware datetime objects.

https://claude.ai/code/session_011CEYKffQAEXRQjcsjGCVaL