### PR TITLE
Fix set subtraction in get_available by using allocation keys

### DIFF
--- a/blockchain/blockchain.py
+++ b/blockchain/blockchain.py
@@ -427,7 +427,7 @@ class Blockchain:
             for tx in blk.transactions:
                 seen.add(tx.uid)
 
-        return seen - self.allocation()
+        return seen - self.allocation().keys()
 
     def proof_of_work(self, block: Block):
         tgt = BIT_OP * self.difficulty


### PR DESCRIPTION
## Summary
Fixed a bug in the `get_available()` method where set subtraction was being performed against a dictionary object instead of its keys.

## Key Changes
- Modified `get_available()` to subtract `self.allocation().keys()` instead of `self.allocation()` from the `seen` set
- This ensures the set operation is performed on comparable types (set of transaction UIDs vs. set of allocation keys)

## Implementation Details
The `allocation()` method returns a dictionary, but the subtraction operation requires both operands to be sets. By explicitly calling `.keys()` on the allocation dictionary, we extract the keys as a set-like object that can be properly subtracted from the `seen` set of transaction UIDs.

https://claude.ai/code/session_01R1nBLDvDA2j7NC5qpppQUa