### PR TITLE
Display P2P port in window title on app startup

### DIFF
--- a/electron/renderer/app.js
+++ b/electron/renderer/app.js
@@ -712,6 +712,13 @@ function startStream() {
 // Wire up all UI events
 // ─────────────────────────────────────────────────────────────────────────────
 document.addEventListener('DOMContentLoaded', () => {
+  // Set window title with P2P port
+  if (window.electronAPI?.getP2PPort) {
+    window.electronAPI.getP2PPort().then(port => {
+      document.title = `Request Chain — Port ${port}`;
+    });
+  }
+
   // Prevent double init
   initCharts();
 


### PR DESCRIPTION
## Summary
Added functionality to display the P2P port number in the application window title when the app initializes.

## Key Changes
- Retrieve the P2P port from the Electron API on `DOMContentLoaded` event
- Update the window title to include the port number in the format "Request Chain — Port {port}"
- Added null-safety check to ensure the `getP2PPort` API method exists before calling it

## Implementation Details
- The P2P port is fetched asynchronously via `window.electronAPI.getP2PPort()`
- The window title is updated once the promise resolves, ensuring the port information is available
- This change executes early in the app lifecycle, right after the DOM is loaded but before chart initialization

https://claude.ai/code/session_019np9dnt7P47NpfrNB81NyG