### PR TITLE
Increase blockchain difficulty from 2 to 4

### DIFF
--- a/electron_backend.py
+++ b/electron_backend.py
@@ -47,7 +47,7 @@ _pub_key = _priv_key.public_key()
 _node_pubkey_hex = serialize_pubkey(_pub_key)
 
 # ── Blockchain state ───────────────────────────────────────────────────────────
-chain: Blockchain = Blockchain.init(CHAIN_PATH, difficulty=2) or Blockchain(difficulty=2)
+chain: Blockchain = Blockchain.init(CHAIN_PATH, difficulty=4) or Blockchain(difficulty=4)
 
 # ── P2P network ───────────────────────────────────────────────────────────────
 _p2p_port = int(sys.argv[1]) if len(sys.argv) > 1 else 6000


### PR DESCRIPTION
## Summary
Increased the proof-of-work difficulty level for the blockchain from 2 to 4, making mining operations more computationally challenging.

## Changes
- Updated blockchain initialization difficulty parameter from `2` to `4` in both the `Blockchain.init()` call and the fallback `Blockchain()` constructor

## Details
This change affects the mining difficulty for all new blocks in the blockchain. The difficulty parameter controls the number of leading zeros required in the hash, making it take approximately 4x longer to mine blocks with the new difficulty level of 4 compared to the previous level of 2.

https://claude.ai/code/session_012Nnjtrx5PhZghib6759GpU